### PR TITLE
Fix/other servers support #34

### DIFF
--- a/src/bics_bot/cogs/commands/intro_cmd.py
+++ b/src/bics_bot/cogs/commands/intro_cmd.py
@@ -5,11 +5,10 @@ from nextcord import application_command, Interaction
 from bics_bot.embeds.logger_embed import LoggerEmbed
 from bics_bot.embeds.logger_embed import WARNING_LEVEL
 from bics_bot.config.server_ids import (
-    CHANNEL_INTRO_ID,
-    ROLE_ADMIN_ID,
     ROLE_INTRO_LIST,
 )
 from bics_bot.utils.file_manipulation import read_txt
+from bics_bot.utils.server_utilities import retrieve_server_ids
 
 
 class IntroCmd(commands.Cog):
@@ -59,11 +58,14 @@ class IntroCmd(commands.Cog):
             None
         """
 
-        if interaction.channel_id != CHANNEL_INTRO_ID:
+        server_ids = retrieve_server_ids(interaction.guild)
+        intro_channel_id = server_ids["channels"]["💡starting-up"]
+
+        if interaction.channel_id != intro_channel_id:
             # Only allow the /intro command to be used inside the
             # starting-up text channel
             msg = (
-                f"Oops something went wrong! Make sure you are on <#{CHANNEL_INTRO_ID}> to send the **/intro** command",
+                f"Oops something went wrong! Make sure you are on <#{intro_channel_id}> to send the **/intro** command",
             )
             await interaction.response.send_message(
                 embed=LoggerEmbed("Warning", msg, WARNING_LEVEL),
@@ -77,7 +79,7 @@ class IntroCmd(commands.Cog):
         if len(user.roles) > 1:
             # User already used /intro once
             msg = (
-                f"You have already introduced yourself! In case you have a role that you think should be changed feel free to ping an <@&{ROLE_ADMIN_ID}>",
+                f"You have already introduced yourself! In case you have a role that you think should be changed feel free to ping an <@&{server_ids['roles']['admin']}>",
             )
             await interaction.response.send_message(
                 embed=LoggerEmbed("Warning", msg, WARNING_LEVEL),
@@ -102,7 +104,7 @@ class IntroCmd(commands.Cog):
         await user.edit(nick=f"{name.capitalize()} {surname[0].upper()}")
         msg = f"""Welcome on board **{name.capitalize()} {surname.capitalize()}**!
             Your role has been updated and you are all set 😉.
-            In case of any question, feel free to ping an <@&{ROLE_ADMIN_ID}>\n\n"""
+            In case of any question, feel free to ping an <@&{server_ids['roles']['admin']}>\n\n"""
 
         if year == "incoming":
             msg = msg + read_txt("./bics_bot/texts/introduction_incoming.txt")

--- a/src/bics_bot/config/server_ids.yaml
+++ b/src/bics_bot/config/server_ids.yaml
@@ -1,0 +1,15 @@
+roles: ['Admin', 'Year 1', 'Year 2', 'Year 3', 'Alumni', 'Erasmus', 'Gamer']
+
+categories:
+  [
+    'Semester 1',
+    'Semester 2',
+    'Semester 3',
+    'Semester 4',
+    'Semester 5',
+    'Semester 6',
+    '🏖 Chilling',
+    'Study Groups',
+  ]
+
+channels: ['💡starting-up']

--- a/src/bics_bot/utils/channels_utils.py
+++ b/src/bics_bot/utils/channels_utils.py
@@ -1,15 +1,8 @@
 from nextcord import Interaction
-from bics_bot.config.server_ids import (
-    CATEGORY_SEMESTER_1_ID,
-    CATEGORY_SEMESTER_2_ID,
-    CATEGORY_SEMESTER_3_ID,
-    CATEGORY_SEMESTER_4_ID,
-    CATEGORY_SEMESTER_5_ID,
-    CATEGORY_SEMESTER_6_ID,
-)
 import csv
 import datetime
 import time
+from bics_bot.utils.server_utilities import retrieve_server_ids
 
 CALENDAR_FILE_PATH = "./bics_bot/data/calendar.csv"
 
@@ -25,13 +18,14 @@ def retrieve_courses_text_channels_names(
     Rerturns:
         List with all courses text channels names
     """
+    server_config = retrieve_server_ids(guild)
     ids = [
-        CATEGORY_SEMESTER_1_ID,
-        CATEGORY_SEMESTER_2_ID,
-        CATEGORY_SEMESTER_3_ID,
-        CATEGORY_SEMESTER_4_ID,
-        CATEGORY_SEMESTER_5_ID,
-        CATEGORY_SEMESTER_6_ID,
+        server_config["categories"]["semester-1"],
+        server_config["categories"]["semester-2"],
+        server_config["categories"]["semester-3"],
+        server_config["categories"]["semester-4"],
+        server_config["categories"]["semester-5"],
+        server_config["categories"]["semester-6"],
     ]
     categories = guild.by_category()
     text_channels = []
@@ -86,13 +80,14 @@ def retrieve_courses_text_channels_by_year(
         dictionary where the key is the year, as yearn and the value is a
         list whith text channel names associated with the year.
     """
+    server_config = retrieve_server_ids(guild)
     ids = [
-        CATEGORY_SEMESTER_1_ID,
-        CATEGORY_SEMESTER_2_ID,
-        CATEGORY_SEMESTER_3_ID,
-        CATEGORY_SEMESTER_4_ID,
-        CATEGORY_SEMESTER_5_ID,
-        CATEGORY_SEMESTER_6_ID,
+        server_config["categories"]["semester-1"],
+        server_config["categories"]["semester-2"],
+        server_config["categories"]["semester-3"],
+        server_config["categories"]["semester-4"],
+        server_config["categories"]["semester-5"],
+        server_config["categories"]["semester-6"],
     ]
     categories = guild.by_category()
     text_channels = {"year1": [], "year2": [], "year3": []}
@@ -126,13 +121,14 @@ def retrieve_courses_text_channels(
         dictionary where the key is the year, as yearn and the value is a
         list whith text channel names associated with the year.
     """
+    server_config = retrieve_server_ids(guild)
     ids = [
-        CATEGORY_SEMESTER_1_ID,
-        CATEGORY_SEMESTER_2_ID,
-        CATEGORY_SEMESTER_3_ID,
-        CATEGORY_SEMESTER_4_ID,
-        CATEGORY_SEMESTER_5_ID,
-        CATEGORY_SEMESTER_6_ID,
+        server_config["categories"]["semester-1"],
+        server_config["categories"]["semester-2"],
+        server_config["categories"]["semester-3"],
+        server_config["categories"]["semester-4"],
+        server_config["categories"]["semester-5"],
+        server_config["categories"]["semester-6"],
     ]
     categories = guild.by_category()
     text_channels = {"year1": {}, "year2": {}, "year3": {}}

--- a/src/bics_bot/utils/server_utilities.py
+++ b/src/bics_bot/utils/server_utilities.py
@@ -1,0 +1,66 @@
+import yaml
+from nextcord import Guild, Role
+
+
+def get_role_id_by_name(guild: Guild, name: str):
+    """
+    TODO: Missing docstrings
+    """
+    for role in guild.roles:
+        if role.name == name:
+            return role.id
+    return None
+
+
+def get_category_id_by_name(guild: Guild, name: str):
+    """
+    TODO: Missing docstrings
+    """
+    for category in guild.categories:
+        if category.name == name:
+            return category.id
+    return None
+
+
+def get_channel_id_by_name(guild: Guild, name: str):
+    """
+    TODO: Missing docstrings
+    """
+    for channel in guild.channels:
+        if channel.name == name:
+            return channel.id
+    return None
+
+
+def retrieve_server_ids(guild: Guild):
+    """
+    TODO: Missing docstrings
+    """
+    with open("./bics_bot/config/server_ids.yaml", "r") as f:
+        server_ids = yaml.safe_load(f)
+        config = {"roles": {}, "channels": {}, "categories": {}}
+
+        for role in server_ids["roles"]:
+            name = role.replace(" ", "-").lower()
+            role_id = get_role_id_by_name(guild, role)
+            if role_id is None:
+                print(f"Role {role} not found")
+                continue
+            config["roles"][name] = role_id
+
+        for category in server_ids["categories"]:
+            name = category.replace(" ", "-").lower()
+            category_id = get_category_id_by_name(guild, category)
+            if category_id is None:
+                print(f"Category {category} not found")
+                continue
+            config["categories"][name] = category_id
+
+        for channel in server_ids["channels"]:
+            name = channel.replace(" ", "-").lower()
+            channel_id = get_channel_id_by_name(guild, channel)
+            if channel_id is None:
+                print(f"Channel {channel} not found")
+                continue
+            config["channels"][name] = channel_id
+    return config


### PR DESCRIPTION
# Description

This PR brings a new functionality to fix the problem of changing the IDS for every different server other than Bics student Server. It now makes use of a YAML file, where we can specify which categories, roles and channels the bot requires, all by names. Therefore, even you are in a server which is not the Bics server, everything should still work as expected. This is because, when their IDs are required, a newly utility function will retrieve the IDs dynamically based on the names.

Fixes #34 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested by replacing where the different hard coded ids were required, only for 3 commands, the `intro`, `enroll` and `unenroll`. In case other commands require this, it has not been checked (reason being for future issues for LOSC)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
